### PR TITLE
Allow class of expanded paper-item to be customized

### DIFF
--- a/addon/templates/components/paper-expansion-panel/expanded/header.hbs
+++ b/addon/templates/components/paper-expansion-panel/expanded/header.hbs
@@ -1,3 +1,3 @@
-{{#paper-item onClick=onClose noink=true as |controls|}}
+{{#paper-item class=class onClick=onClose noink=true as |controls|}}
   {{yield controls}}
 {{/paper-item}}


### PR DESCRIPTION
Makes behaviour consistent between `collapsed` and `expanded/header` components