### PR TITLE
pass the event object to onExpandedChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Don't forget to import your styles in your `app.scss` **after** importing ember 
 ### `{{#paper-expansion-panel as |panel|}}`
 
 - `expanded` - defaults to `false` - this toggles the expansion panel between expanded and collapsed modes.
-- `onExpandedChange` - an action that is sent when a the panel is expanded or collapsed. You get as an argument a boolean with the current state of `expanded`
+- `onExpandedChange` - an action that is sent when a the panel is expanded or collapsed. You get two arguments, a boolean with the current state of `expanded` and the event object
 
 This component yields a hash that contains:
 - `collapsed` and `expanded` components

--- a/addon/components/paper-expansion-panel.js
+++ b/addon/components/paper-expansion-panel.js
@@ -8,17 +8,17 @@ export default Component.extend({
 
   expanded: false,
 
-  expand() {
+  expand(event) {
     this.set('expanded', true);
     if (this.get('onExpandedChange')) {
-      this.get('onExpandedChange')(true);
+      this.get('onExpandedChange')(true, event);
     }
   },
 
-  collapse() {
+  collapse(event) {
     this.set('expanded', false);
     if (this.get('onExpandedChange')) {
-      this.get('onExpandedChange')(false);
+      this.get('onExpandedChange')(false, event);
     }
   },
 


### PR DESCRIPTION
## Why?
In trying to emulate the collapse component on the demo site for ember paper, I chose this addon and didn't notice for awhile that when expanding/collapsing the panel in the menu drawer that it would close the menu. So in my application with this branch, I'm using it in the following way:
```handlebars
{{#paper-expansion-panel onExpandedChange=(action 'onExpandedChange') as |panel|}}
  ...
{{/paper-expansion-panel}}
```
```js
actions: {
  onExpandedChange(isExpanded, ev) { ev.stopPropagation(); }
}
```
This works for me

## Alternative
This could also be accomplished by a new argument to the component like the `bubbles` argument that was once on `{{action}}`. I chose the former implementation just because it was less lines and more flexible, but not wed to the current approach

