### PR TITLE
Fixed #8 - Nested expansion panel get instantiated/destroyed every time me the parent panel get expanded/collapsed

### DIFF
--- a/addon/templates/components/paper-expansion-panel/collapsed.hbs
+++ b/addon/templates/components/paper-expansion-panel/collapsed.hbs
@@ -1,7 +1,7 @@
-{{#unless expanded}}
+<div class={{if expanded "hide" ""}}>
   {{#paper-item class=class onClick=(action onExpand)
     onMouseEnter=onMouseEnter
     onMouseLeave=onMouseLeave as |controls|}}
     {{yield controls}}
   {{/paper-item}}
-{{/unless}}
+</div>

--- a/addon/templates/components/paper-expansion-panel/expanded.hbs
+++ b/addon/templates/components/paper-expansion-panel/expanded.hbs
@@ -1,7 +1,7 @@
-{{#if expanded}}
+<div class={{if expanded "" "hide"}}>
   {{yield (hash
     header=(component "paper-expansion-panel/expanded/header" onClose=onClose)
     content=(component "paper-expansion-panel/expanded/content")
     footer=(component "paper-expansion-panel/expanded/footer")
   )}}
-{{/if}}
+</div>

--- a/app/styles/ember-paper-expansion-panel.scss
+++ b/app/styles/ember-paper-expansion-panel.scss
@@ -81,4 +81,8 @@ md-expansion-panel {
     line-height: 48px;
     padding: 10px 8px 10px 24px;
   }
+
+  .hide {
+    display: none;
+  }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -109,6 +109,131 @@
 
 {{/paper-list}}
 
+{{#paper-list}}
+  {{#paper-subheader}}Customized example - Nested panel{{/paper-subheader}}
+  {{#paper-expansion-panel as |panel|}}
+    {{#panel.collapsed}}
+      <div class="md-panel-title">Title {{item}}</div>
+      <div class="md-panel-summary">Summary - Parent Panel</div>
+
+      <div class="actions">
+        {{#paper-button iconButton=true onClick=(action "alert" "time") bubbles=false}}
+          {{paper-icon "flash-on"}}
+        {{/paper-button}}
+
+        {{#paper-button iconButton=true onClick=(action "alert" "time") bubbles=false}}
+          {{paper-icon "access-time"}}
+        {{/paper-button}}
+
+        {{#paper-menu position="right target" as |menu|}}
+          {{#menu.trigger}}
+            {{#paper-button iconButton=true}}
+              {{paper-icon "more-vert"}}
+            {{/paper-button}}
+          {{/menu.trigger}}
+          {{#menu.content as |content|}}
+            {{#content.menu-item onClick=(action "alert")}}
+              {{paper-icon "phone"}} <span>Action 1</span>
+            {{/content.menu-item}}
+            {{#content.menu-item onClick=(action "alert")}}
+              {{paper-icon "phone"}} <span>Action 2</span>
+            {{/content.menu-item}}
+            {{#content.menu-item onClick=(action "alert")}}
+              {{paper-icon "phone"}} <span>Action 3</span>
+            {{/content.menu-item}}
+          {{/menu.content}}
+        {{/paper-menu}}
+
+        {{paper-icon "keyboard_arrow_down"}}
+      </div>
+    {{/panel.collapsed}}
+
+    {{#panel.expanded as |expanded|}}
+      {{#expanded.header}}
+        <div class="md-panel-title">Expanded title</div>
+        <div class="md-panel-summary">Expanded summary</div>
+
+        {{paper-icon "keyboard_arrow_up"}}
+      {{/expanded.header}}
+
+      {{#expanded.content}}
+        {{#paper-expansion-panel as |panel|}}
+          {{#panel.collapsed}}
+            <div class="md-panel-title">Title {{item}}</div>
+            <div class="md-panel-summary">Summary - Child Panel</div>
+
+            <div class="actions">
+              {{#paper-button iconButton=true onClick=(action "alert" "time") bubbles=false}}
+                {{paper-icon "flash-on"}}
+              {{/paper-button}}
+
+              {{#paper-button iconButton=true onClick=(action "alert" "time") bubbles=false}}
+                {{paper-icon "access-time"}}
+              {{/paper-button}}
+
+              {{#paper-menu position="right target" as |menu|}}
+                {{#menu.trigger}}
+                  {{#paper-button iconButton=true}}
+                    {{paper-icon "more-vert"}}
+                  {{/paper-button}}
+                {{/menu.trigger}}
+                {{#menu.content as |content|}}
+                  {{#content.menu-item onClick=(action "alert")}}
+                    {{paper-icon "phone"}} <span>Action 1</span>
+                  {{/content.menu-item}}
+                  {{#content.menu-item onClick=(action "alert")}}
+                    {{paper-icon "phone"}} <span>Action 2</span>
+                  {{/content.menu-item}}
+                  {{#content.menu-item onClick=(action "alert")}}
+                    {{paper-icon "phone"}} <span>Action 3</span>
+                  {{/content.menu-item}}
+                {{/menu.content}}
+              {{/paper-menu}}
+
+              {{paper-icon "keyboard_arrow_down"}}
+            </div>
+          {{/panel.collapsed}}
+
+          {{#panel.expanded as |expanded|}}
+            {{#expanded.header}}
+              <div class="md-panel-title">Expanded title</div>
+              <div class="md-panel-summary">Expanded summary</div>
+
+              {{paper-icon "keyboard_arrow_up"}}
+            {{/expanded.header}}
+
+            {{#expanded.content}}
+              Content
+            {{/expanded.content}}
+
+            {{#expanded.footer}}
+              <span class="flex"></span>
+              {{#paper-button onClick=(action panel.collapse)}}
+                Cancel
+              {{/paper-button}}
+              {{#paper-button primary=true onClick=(action panel.collapse)}}
+                Save
+              {{/paper-button}}
+            {{/expanded.footer}}
+
+          {{/panel.expanded}}
+        {{/paper-expansion-panel}}
+      {{/expanded.content}}
+
+      {{#expanded.footer}}
+        <span class="flex"></span>
+        {{#paper-button onClick=(action panel.collapse)}}
+          Cancel
+        {{/paper-button}}
+        {{#paper-button primary=true onClick=(action panel.collapse)}}
+          Save
+        {{/paper-button}}
+      {{/expanded.footer}}
+
+    {{/panel.expanded}}
+  {{/paper-expansion-panel}}
+{{/paper-list}}
+
 {{#if dialogOpen}}
   {{#paper-dialog onClose=(action (mut dialogOpen) false)}}
     {{#paper-dialog-content}}

--- a/tests/integration/components/paper-expansion-panel-test.js
+++ b/tests/integration/components/paper-expansion-panel-test.js
@@ -49,7 +49,7 @@ module('Integration | Component | paper expansion panel', function(hooks) {
 
     await click('button.md-button');
 
-    assert.equal(find('md-list-item').textContent.trim(), 'expanded header');
+    assert.equal(find('md-list-item').textContent.trim(), 'collapsed content');
     assert.equal(find('md-expansion-panel-content').textContent.trim(), 'expanded content');
     assert.equal(find('md-expansion-panel-footer').textContent.trim(), 'expanded footer');
   });
@@ -80,7 +80,7 @@ module('Integration | Component | paper expansion panel', function(hooks) {
       {{/paper-expansion-panel}}
     `);
 
-    assert.equal(find('md-list-item').textContent.trim(), 'expanded header');
+    assert.equal(find('md-list-item').textContent.trim(), 'collapsed content');
     assert.equal(find('md-expansion-panel-content').textContent.trim(), 'expanded content');
     assert.equal(find('md-expansion-panel-footer').textContent.trim(), 'expanded footer');
   });
@@ -115,7 +115,7 @@ module('Integration | Component | paper expansion panel', function(hooks) {
 
     this.set('expanded', true);
 
-    assert.equal(find('md-list-item').textContent.trim(), 'expanded header');
+    assert.equal(find('md-list-item').textContent.trim(), 'collapsed content');
     assert.equal(find('md-expansion-panel-content').textContent.trim(), 'expanded content');
     assert.equal(find('md-expansion-panel-footer').textContent.trim(), 'expanded footer');
   });
@@ -190,7 +190,7 @@ module('Integration | Component | paper expansion panel', function(hooks) {
     await click('button.md-button');
 
     this.set('onExpandedChange', (state) => {
-      assert.notOk(state, 'action was sent with false');
+      assert.ok(state, 'action was sent with true');
     });
 
     await click('button.md-button');


### PR DESCRIPTION
The nested panel expand/collapse state get remembered when we collapse/expand parent panel.